### PR TITLE
fix clients to use https://bsd.ac

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Make sure that whatever link is provided to the `-d ` domain option, is also abl
 Define these functions somewhere in the dot files of the desired shell (they work on all POSIX compliant shells).
 
 ```
-: ${P_SERVER=bsd.ac}
+: ${P_SERVER=https://bsd.ac}
 : ${P_PORT=42069}
 : ${P_MAXTIME=30}
 

--- a/clients/POSIX_shell_client.sh
+++ b/clients/POSIX_shell_client.sh
@@ -5,7 +5,7 @@
 # Requirements for encrypted message sending:
 # - LibreSSL / OpenSSL / GnuTLS
 
-: ${P_SERVER=bsd.ac}
+: ${P_SERVER=https://bsd.ac}
 : ${P_PORT=42069}
 : ${P_TIME=week}
 : ${P_MAXTIME=30}


### PR DESCRIPTION
Just "bsd.ac" doesn't work anymore.

Signed-off-by: Érico Nogueira <erico.erc@gmail.com>

Closes #6 

That said, was it expected that HTTP would stop working completely?